### PR TITLE
fix: raise error when Infura project Id is not set

### DIFF
--- a/ape_infura/providers.py
+++ b/ape_infura/providers.py
@@ -2,6 +2,7 @@ import os
 from typing import Iterator
 
 from ape.api import ProviderAPI, ReceiptAPI, TransactionAPI
+from ape.exceptions import ProviderError
 from web3 import HTTPProvider, Web3  # type: ignore
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
 
@@ -35,13 +36,13 @@ class Infura(ProviderAPI):
         return self._web3.eth.generate_gas_price()
 
     def get_nonce(self, address: str) -> int:
-        return self._web3.eth.getTransactionCount(address)  # type: ignore
+        return self._web3.eth.get_transaction_count(address)  # type: ignore
 
     def get_balance(self, address: str) -> int:
-        return self._web3.eth.getBalance(address)  # type: ignore
+        return self._web3.eth.get_balance(address)  # type: ignore
 
     def get_code(self, address: str) -> bytes:
-        return self._web3.eth.getCode(address)  # type: ignore
+        return self._web3.eth.get_code(address)  # type: ignore
 
     def send_call(self, txn: TransactionAPI) -> bytes:
         data = txn.encode()

--- a/ape_infura/providers.py
+++ b/ape_infura/providers.py
@@ -9,7 +9,13 @@ from web3.gas_strategies.rpc import rpc_gas_price_strategy
 _ENVIRONMENT_VARIABLE_NAMES = ("WEB3_INFURA_PROJECT_ID", "WEB3_INFURA_API_KEY")
 
 
-class MissingProjectKeyError(ProviderError):
+class InfuraProviderError(ProviderError):
+    """
+    An error raised by the Infura provider plugin.
+    """
+
+
+class MissingProjectKeyError(InfuraProviderError):
     def __init__(self):
         env_var_str = ", ".join([f"${n}" for n in _ENVIRONMENT_VARIABLE_NAMES])
         super().__init__(f"Must set one of {env_var_str}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
 
+[tool.mypy]
+exclude = "build/"
+
 [tool.setuptools_scm]
 write_to = "ape_infura/version.py"
 
@@ -32,6 +35,7 @@ exclude = '''
 [tool.pytest.ini_options]
 addopts = """
     -n auto
+    -p no:ape_test
     --cov-branch
     --cov-report term
     --cov-report html

--- a/setup.py
+++ b/setup.py
@@ -60,10 +60,10 @@ setup(
     url="https://github.com/ApeWorX/ape-infura",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.1.0a21",
+        "eth-ape>=0.1.0a24",
         "importlib-metadata ; python_version<'3.8'",
     ],  # NOTE: Add 3rd party libraries here
-    python_requires=">=3.6,<4",
+    python_requires=">=3.7,<4",
     extras_require=extras_require,
     py_modules=["ape_infura"],
     license="Apache-2.0",

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     url="https://github.com/ApeWorX/ape-infura",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.1.0a24",
+        "eth-ape>=0.1.0a26",
         "importlib-metadata ; python_version<'3.8'",
     ],  # NOTE: Add 3rd party libraries here
     python_requires=">=3.7,<4",


### PR DESCRIPTION
### What I did

fixes: #3 

Also dust it off in preparation of some custom error handling I want to add eventually related to `TransactionError` and reverts.

### How I did it

Raise a custom error that is a `ProviderError` when the env vars are not set. Displays the possible env vars to set in the error message.

### How to verify it

```bash
# Unset the env var if needed
unset WEB3_INFURA_PROJECT_ID
# Run command
ape run script --network ethereum:rinkeby:infura
# It should fail with a nice message
# Then reset the env var and all should work as normal :)
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
