### PR TITLE
fix: issue preventing Eth calls from working

### DIFF
--- a/ape_infura/providers.py
+++ b/ape_infura/providers.py
@@ -44,8 +44,7 @@ class Infura(ProviderAPI):
         return self._web3.eth.getCode(address)  # type: ignore
 
     def send_call(self, txn: TransactionAPI) -> bytes:
-        data = txn.encode()
-        return self._web3.eth.call(data)
+        return self._web3.eth.call(txn.as_dict())
 
     def get_transaction(self, txn_hash: str) -> ReceiptAPI:
         # TODO: Work on API that let's you work with ReceiptAPI and re-send transactions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
 
+[tool.mypy]
+exclude = "build/"
+
 [tool.setuptools_scm]
 write_to = "ape_infura/version.py"
 
@@ -32,6 +35,7 @@ exclude = '''
 [tool.pytest.ini_options]
 addopts = """
     -n auto
+    -p no:ape_test
     --cov-branch
     --cov-report term
     --cov-report html

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     url="https://github.com/ApeWorX/ape-infura",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.1.0a21",
+        "eth-ape>=0.1.0a26",
         "importlib-metadata ; python_version<'3.8'",
     ],  # NOTE: Add 3rd party libraries here
     python_requires=">=3.7,<4",

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         "eth-ape>=0.1.0a21",
         "importlib-metadata ; python_version<'3.8'",
     ],  # NOTE: Add 3rd party libraries here
-    python_requires=">=3.6,<4",
+    python_requires=">=3.7,<4",
     extras_require=extras_require,
     py_modules=["ape_infura"],
     license="Apache-2.0",


### PR DESCRIPTION
### What I did

Same thing we had to do for `ape-geth` (fka as `ape-http`) (https://github.com/ApeWorX/ape/pull/190) but for here

### How I did it

Noticed I couldn't make calls with infura
Looked up how I fixed it in the ape PR
Applied fix
Tested, it worked!

### How to verify it

Create a simple contract like this:

```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.6.0;

contract MyNumber {
    int public number = 42;
}
```

Call it in a script like this:

```python
from ape import accounts
from ape import project


def main():
    test_account = accounts.load("hardhat_0")
    contract_type = project.MyNumber
    contract = test_account.deploy(contract_type)
    my_num = contract.number(sender=test_account)
    print(my_num)

```

Use Infura:

```bash
ape run get_number --network ethereum:rinkeby:infura
```

It should print out `42`.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)

