### PR TITLE
feat: make Infura an upstream provider

### DIFF
--- a/ape_infura/providers.py
+++ b/ape_infura/providers.py
@@ -1,6 +1,6 @@
 import os
 
-from ape.api import ReceiptAPI, TransactionAPI, Web3Provider, UpstreamProvider
+from ape.api import ReceiptAPI, TransactionAPI, UpstreamProvider, Web3Provider
 from ape.exceptions import ContractLogicError, ProviderError, TransactionError, VirtualMachineError
 from ape.utils import gas_estimation_error_message
 from web3 import HTTPProvider, Web3  # type: ignore


### PR DESCRIPTION
### What I did

Make `Infura` declared as an `UpstreamProvider` so it can be used in `ape-hardhat` `MainnetForkProvider`

### How I did it

Import the mixin class
Set the URI in the `__post_init__`
Return the URI in the API method

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
