### PR TITLE
fix: add PoA middleware to Ethereum:goerli since it started as PoA

### DIFF
--- a/ape_infura/provider.py
+++ b/ape_infura/provider.py
@@ -55,8 +55,12 @@ class Infura(Web3Provider, UpstreamProvider):
     def connect(self):
         self._web3 = Web3(HTTPProvider(self.uri))
 
-        # optimism:mainnet, optimism:goerli, or polygon:mumbai
-        if self._web3.eth.chain_id in (10, 420, 137, 80001):
+        # Any chain that *began* as PoA needs the middleware for pre-merge blocks
+        ethereum_goerli = 5
+        optimism = (10, 420)
+        polygon = (137, 80001)
+
+        if self._web3.eth.chain_id in (ethereum_goerli, *optimism, *polygon):
             self._web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
         self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -24,6 +24,6 @@ def test_infura(ecosystem, network):
     with network_cls.use_provider("infura") as provider:
         assert isinstance(provider, Infura)
         assert provider.get_balance(ZERO_ADDRESS) > 0
-        assert provider.get_block("latest")
+        assert provider.get_block(0)
         ecosystem_uri = "" if ecosystem == "ethereum" else f"{ecosystem}-"
         assert f"https://{ecosystem_uri}{network}.infura.io/v3/" in provider.uri


### PR DESCRIPTION
### What I did

Noticed errors when forking Goerli.
It is because we need the first block hash.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
