### PR TITLE
feat: add sepolia network [APE-696]

### DIFF
--- a/ape_infura/__init__.py
+++ b/ape_infura/__init__.py
@@ -6,6 +6,7 @@ NETWORKS = {
     "ethereum": [
         "mainnet",
         "goerli",
+        "sepolia",
     ],
     "arbitrum": [
         "mainnet",

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     url="https://github.com/ApeWorX/ape-infura",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.0,<0.7",
+        "eth-ape>=0.6.5,<0.7",
     ],
     python_requires=">=3.8,<3.11",
     extras_require=extras_require,

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -10,6 +10,7 @@ from ape_infura.provider import Infura
     [
         ("ethereum", "mainnet"),
         ("ethereum", "goerli"),
+        ("ethereum", "sepolia"),
         ("arbitrum", "mainnet"),
         ("arbitrum", "goerli"),
         ("optimism", "mainnet"),


### PR DESCRIPTION
### What I did

Add the sepolia testnet to the etherum ecosystem, following https://github.com/ApeWorX/ape/pull/1331

### How I did it

Add references to it where it seemed suitable.

### How to verify it

```sh
ape networks list
ape console --network ethereum:sepolia:infura
```

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated (shows up in the `ape networks list` command outptut)
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
