### PR TITLE
feat: add linea network support [APE-1170]

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This plugin supports the following ecosystems:
 - Polygon
 - Arbitrum
 - Optimism
+- Linea
 
 ## Dependencies
 

--- a/ape_infura/__init__.py
+++ b/ape_infura/__init__.py
@@ -20,6 +20,10 @@ NETWORKS = {
         "mainnet",
         "mumbai",
     ],
+    "linea": [
+        "mainnet",
+        "goerli",
+    ],
 }
 
 

--- a/ape_infura/provider.py
+++ b/ape_infura/provider.py
@@ -59,8 +59,9 @@ class Infura(Web3Provider, UpstreamProvider):
         ethereum_goerli = 5
         optimism = (10, 420)
         polygon = (137, 80001)
+        linea = (59144, 59140)
 
-        if self._web3.eth.chain_id in (ethereum_goerli, *optimism, *polygon):
+        if self._web3.eth.chain_id in (ethereum_goerli, *optimism, *polygon, *linea):
             self._web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
         self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ extras_require = {
         "ape-arbitrum",
         "ape-optimism",
         "ape-polygon",
+        "ape-linea",
     ],
     "lint": [
         "black>=23.3.0,<24",  # auto-formatter and linter

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -17,6 +17,8 @@ from ape_infura.provider import Infura
         ("optimism", "goerli"),
         ("polygon", "mainnet"),
         ("polygon", "mumbai"),
+        ["linea", "mainnet"],
+        ["linea", "goerli"],
     ],
 )
 def test_infura(ecosystem, network):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -17,8 +17,8 @@ from ape_infura.provider import Infura
         ("optimism", "goerli"),
         ("polygon", "mainnet"),
         ("polygon", "mumbai"),
-        ["linea", "mainnet"],
-        ["linea", "goerli"],
+        ("linea", "mainnet"),
+        ("linea", "goerli"),
     ],
 )
 def test_infura(ecosystem, network):


### PR DESCRIPTION
### What I did

Add the Linea network (Mainnet and goerli testnet) support to the plugin , 


### How I did it
* add linea network information to plugin
* add new test in test.

### How to verify it
```
pip install ape-linea
ape networks list
ape console --network linea:goerli:infura
ape console --network linea:mainnet:infura
```


### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
