### PR TITLE
feat: add support for `.http_uri` and `.ws_uri` in ProviderAPI v0.6.19 [APE-1381]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
     -   id: check-yaml
 
@@ -10,24 +10,24 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.9.1
     hooks:
       - id: black
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.5.1
     hooks:
     -   id: mypy
         additional_dependencies: [types-PyYAML, types-requests, types-setuptools, pydantic]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.14
+    rev: 0.7.17
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,4 +46,4 @@ A pull request represents the start of a discussion, and doesn't necessarily nee
 If you are opening a work-in-progress pull request to verify that it passes CI tests, please consider
 [marking it as a draft](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
 
-Join the Ethereum Python [Discord](https://discord.gg/PcEJ54yX) if you have any questions.
+Join the ApeWorX [Discord](https://discord.gg/apeworx) if you have any questions.

--- a/README.md
+++ b/README.md
@@ -58,5 +58,6 @@ To connect to Infura from a Python script, use the `networks` top-level manager:
 from ape import networks
 
 with networks.parse_network_choice("ethereum:mainnet:infura") as provider:
-    ...
+    # Also, access the websocket URI:
+    print(provider.ws_uri)
 ```

--- a/ape_infura/provider.py
+++ b/ape_infura/provider.py
@@ -56,7 +56,8 @@ class Infura(Web3Provider, UpstreamProvider):
     @property
     def ws_uri(self) -> str:
         # NOTE: Overriding `Web3Provider.ws_uri` implementation
-        return "ws" + self.uri[4:]  # Remove `http` in default URI w/ `ws`
+        # Remove `http` in default URI w/ `ws`, also infura adds `/ws` to URI
+        return "ws" + self.uri[4:].replace("v3", "ws/v3")
 
     @property
     def connection_str(self) -> str:

--- a/ape_infura/provider.py
+++ b/ape_infura/provider.py
@@ -49,6 +49,16 @@ class Infura(Web3Provider, UpstreamProvider):
         return network_uri
 
     @property
+    def http_uri(self) -> str:
+        # NOTE: Overriding `Web3Provider.http_uri` implementation
+        return self.uri
+
+    @property
+    def ws_uri(self) -> str:
+        # NOTE: Overriding `Web3Provider.ws_uri` implementation
+        return "ws" + self.uri[4:]  # Remove `http` in default URI w/ `ws`
+
+    @property
     def connection_str(self) -> str:
         return self.uri
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
+requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0,<8"]
 
 [tool.mypy]
 exclude = "build/"

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,12 @@ extras_require = {
         "websocket-client",  # Used for web socket integration testing
     ],
     "lint": [
-        "black>=23.3.0,<24",  # auto-formatter and linter
-        "mypy>=0.991,<1",  # Static type analyzer
-        "flake8>=6.0.0,<7",  # Style linter
+        "black>=23.9.1,<24",  # auto-formatter and linter
+        "mypy>=1.5.1,<2",  # Static type analyzer
+        "flake8>=6.1.0,<7",  # Style linter
         "isort>=5.10.1,<6",  # Import sorting linter
         "types-setuptools",  # Needed due to mypy typeshed
-        "mdformat>=0.7.16",  # Auto-formatter for markdown
+        "mdformat>=0.7.17",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
     ],

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ extras_require = {
         "ape-optimism",
         "ape-polygon",
         "ape-linea",
+        "websocket-client",  # Used for web socket integration testing
     ],
     "lint": [
         "black>=23.3.0,<24",  # auto-formatter and linter

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     url="https://github.com/ApeWorX/ape-infura",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.5,<0.7",
+        "eth-ape>=0.6.19,<0.7",
     ],
     python_requires=">=3.8,<4",
     extras_require=extras_require,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import ape
 import pytest
 
+from ape_infura import NETWORKS
+
 
 @pytest.fixture
 def accounts():
@@ -15,3 +17,11 @@ def Contract():
 @pytest.fixture
 def networks():
     return ape.networks
+
+
+@pytest.fixture(params=[(name, net) for name, values in NETWORKS.items() for net in values])
+def provider(networks, request):
+    ecosystem_cls = networks.get_ecosystem(request.param[0])
+    network_cls = ecosystem_cls.get_network(request.param[1])
+    with network_cls.use_provider("infura") as provider:
+        yield provider

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -26,6 +26,8 @@ def test_infura(ecosystem, network):
     network_cls = ecosystem_cls.get_network(network)
     with network_cls.use_provider("infura") as provider:
         assert isinstance(provider, Infura)
+        assert provider.http_uri.startswith("https")
+        assert provider.ws_uri.startswith("wss")
         assert provider.get_balance(ZERO_ADDRESS) > 0
         assert provider.get_block(0)
         ecosystem_uri = "" if ecosystem == "ethereum" else f"{ecosystem}-"

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,34 +1,28 @@
 import pytest
-from ape import networks
+import websocket  # type: ignore
 from ape.utils import ZERO_ADDRESS
 
 from ape_infura.provider import Infura
 
 
-@pytest.mark.parametrize(
-    "ecosystem,network",
-    [
-        ("ethereum", "mainnet"),
-        ("ethereum", "goerli"),
-        ("ethereum", "sepolia"),
-        ("arbitrum", "mainnet"),
-        ("arbitrum", "goerli"),
-        ("optimism", "mainnet"),
-        ("optimism", "goerli"),
-        ("polygon", "mainnet"),
-        ("polygon", "mumbai"),
-        ("linea", "mainnet"),
-        ("linea", "goerli"),
-    ],
-)
-def test_infura(ecosystem, network):
-    ecosystem_cls = networks.get_ecosystem(ecosystem)
-    network_cls = ecosystem_cls.get_network(network)
-    with network_cls.use_provider("infura") as provider:
-        assert isinstance(provider, Infura)
-        assert provider.http_uri.startswith("https")
-        assert provider.ws_uri.startswith("wss")
-        assert provider.get_balance(ZERO_ADDRESS) > 0
-        assert provider.get_block(0)
-        ecosystem_uri = "" if ecosystem == "ethereum" else f"{ecosystem}-"
-        assert f"https://{ecosystem_uri}{network}.infura.io/v3/" in provider.uri
+def test_infura_http(provider):
+    ecosystem = provider.network.ecosystem.name
+    network = provider.network.name
+    assert isinstance(provider, Infura)
+    assert provider.http_uri.startswith("https")
+    assert provider.get_balance(ZERO_ADDRESS) > 0
+    assert provider.get_block(0)
+    ecosystem_uri = "" if ecosystem == "ethereum" else f"{ecosystem}-"
+    assert f"https://{ecosystem_uri}{network}.infura.io/v3/" in provider.uri
+
+
+def test_infura_ws(provider):
+    assert provider.ws_uri.startswith("wss")
+
+    try:
+        ws = websocket.WebSocket()
+        ws.connect(provider.ws_uri)
+        ws.close()
+
+    except Exception as err:
+        pytest.fail(f"Websocket URI not accessible. Reason: {err}")


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
