### PR TITLE
fix: limit to websocket capable ecosystems [APE-1492]

### DIFF
--- a/ape_infura/provider.py
+++ b/ape_infura/provider.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 from ape.api import UpstreamProvider, Web3Provider
 from ape.exceptions import ContractLogicError, ProviderError, VirtualMachineError
@@ -9,6 +9,12 @@ from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.middleware import geth_poa_middleware
 
 _ENVIRONMENT_VARIABLE_NAMES = ("WEB3_INFURA_PROJECT_ID", "WEB3_INFURA_API_KEY")
+# NOTE: https://docs.infura.io/learn/websockets#supported-networks
+_WEBSOCKET_CAPABLE_ECOSYSTEMS = {
+    "ethereum",
+    "polygon",
+    "linea",
+}
 
 
 class InfuraProviderError(ProviderError):
@@ -54,8 +60,11 @@ class Infura(Web3Provider, UpstreamProvider):
         return self.uri
 
     @property
-    def ws_uri(self) -> str:
+    def ws_uri(self) -> Optional[str]:
         # NOTE: Overriding `Web3Provider.ws_uri` implementation
+        if self.network.ecosystem.name not in _WEBSOCKET_CAPABLE_ECOSYSTEMS:
+            return None
+
         # Remove `http` in default URI w/ `ws`, also infura adds `/ws` to URI
         return "ws" + self.uri[4:].replace("v3", "ws/v3")
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -2,7 +2,7 @@ import pytest
 import websocket  # type: ignore
 from ape.utils import ZERO_ADDRESS
 
-from ape_infura.provider import Infura
+from ape_infura.provider import _WEBSOCKET_CAPABLE_ECOSYSTEMS, Infura
 
 
 def test_infura_http(provider):
@@ -17,6 +17,11 @@ def test_infura_http(provider):
 
 
 def test_infura_ws(provider):
+    ecosystem = provider.network.ecosystem.name
+    if ecosystem not in _WEBSOCKET_CAPABLE_ECOSYSTEMS:
+        assert provider.ws_uri == None
+        return
+
     assert provider.ws_uri.startswith("wss")
 
     try:

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -19,7 +19,7 @@ def test_infura_http(provider):
 def test_infura_ws(provider):
     ecosystem = provider.network.ecosystem.name
     if ecosystem not in _WEBSOCKET_CAPABLE_ECOSYSTEMS:
-        assert provider.ws_uri == None
+        assert provider.ws_uri is None
         return
 
     assert provider.ws_uri.startswith("wss")


### PR DESCRIPTION
### What I did

Noticed that infura only supports 3 networks for websockets: https://docs.infura.io/learn/websockets#supported-networks

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
