### PR TITLE
refactor!: remove goerli network from arbitrum and optimism

### DIFF
--- a/ape_infura/__init__.py
+++ b/ape_infura/__init__.py
@@ -10,12 +10,10 @@ NETWORKS = {
     ],
     "arbitrum": [
         "mainnet",
-        "goerli",
         "sepolia",
     ],
     "optimism": [
         "mainnet",
-        "goerli",
         "sepolia",
     ],
     "polygon": [


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #73 

BREAKING CHANGE: "goerli" no longer a valid value for arbitrum or optimism.

### How I did it

Removed "goerli" entries for arbitrum and optimism. The tests fail otherwise.

### How to verify it

### Checklist

- [X] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [X] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
