### PR TITLE
refactor: remove goerli

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ export WEB3_INFURA_PROJECT_ID=MY_API_TOKEN
 To use the Infura provider plugin in most commands, set it via the `--network` option:
 
 ```bash
-ape console --network ethereum:goerli:infura
+ape console --network ethereum:sepolia:infura
 ```
 
 To connect to Infura from a Python script, use the `networks` top-level manager:

--- a/ape_infura/__init__.py
+++ b/ape_infura/__init__.py
@@ -5,7 +5,6 @@ from .provider import Infura
 NETWORKS = {
     "ethereum": [
         "mainnet",
-        "goerli",
         "sepolia",
     ],
     "arbitrum": [
@@ -24,7 +23,6 @@ NETWORKS = {
     # TODO: Comment out after ape-linea supports 0.7
     # "linea": [
     #     "mainnet",
-    #     "goerli",
     # ],
 }
 

--- a/ape_infura/provider.py
+++ b/ape_infura/provider.py
@@ -79,12 +79,12 @@ class Infura(Web3Provider, UpstreamProvider):
         self._web3 = Web3(HTTPProvider(self.uri))
 
         # Any chain that *began* as PoA needs the middleware for pre-merge blocks
-        ethereum_goerli = 5
+        ethereum_sepolia = 11155111
         optimism = (10, 420)
         polygon = (137, 80001, 80002)
         linea = (59144, 59140)
 
-        if self._web3.eth.chain_id in (ethereum_goerli, *optimism, *polygon, *linea):
+        if self._web3.eth.chain_id in (ethereum_sepolia, *optimism, *polygon, *linea):
             self._web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
         self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)


### PR DESCRIPTION
### What I did

https://blog.ethereum.org/2023/11/30/goerli-lts-update
https://www.alchemy.com/blog/goerli-faucet-deprecation

Goerli support on all networks is ending soon:
- February 16th - [Base Goerli](https://www.alchemy.com/blog/base-goerli-testnet-deprecation)
- March 7th - [Optimism Goerli](https://www.alchemy.com/blog/optimism-goerli-testnet-deprecation)
- March 18th - [Arbitrum Goerli](https://www.alchemy.com/blog/arbitrum-goerli-testnet-deprecation)
- April 1st - [Ethereum Goerli](https://www.alchemy.com/blog/ethereum-goerli-testnet-deprecation)
- April 6th - [Polygon zkEVM Goerli](https://www.alchemy.com/blog/polygon-zkevm-cardona-is-live)
- April 11th - [Starknet Goerli](https://www.alchemy.com/blog/starknet-sepolia-is-live)
- April 13th - [Polygon Mumbai](https://www.alchemy.com/blog/polygon-mumbai-testnet-deprecation)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
