### PR TITLE
feat: added option to load multiple api keys selected at random order

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,6 +82,7 @@ jobs:
           run: pytest -m "not fuzzing" -s --cov=src -n auto
           env:
             WEB3_INFURA_PROJECT_ID: ${{ secrets.WEB3_INFURA_PROJECT_ID }}
+            WEB3_INFURA_PROJECT_IDS: ${{ secrets.WEB3_INFURA_PROJECT_IDS }}
 
 # NOTE: uncomment this block after you've marked tests with @pytest.mark.fuzzing
 #    fuzzing:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,7 +82,6 @@ jobs:
           run: pytest -m "not fuzzing" -s --cov=src -n auto
           env:
             WEB3_INFURA_PROJECT_ID: ${{ secrets.WEB3_INFURA_PROJECT_ID }}
-            WEB3_INFURA_PROJECT_IDS: ${{ secrets.WEB3_INFURA_PROJECT_IDS }}
 
 # NOTE: uncomment this block after you've marked tests with @pytest.mark.fuzzing
 #    fuzzing:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Either in your current terminal session or in your root RC file (e.g. `.bashrc`)
 
 ```bash
 export WEB3_INFURA_PROJECT_ID=MY_API_TOKEN
+
+# Multple tokens
+export WEB3_INFURA_PROJECT_ID=MY_API_TOKEN1, MY_API_TOKEN2
 ```
 
 To use the Infura provider plugin in most commands, set it via the `--network` option:

--- a/ape_infura/provider.py
+++ b/ape_infura/provider.py
@@ -115,7 +115,7 @@ class Infura(Web3Provider, UpstreamProvider):
         self.disconnect()
         self.load_api_keys()
         self.network_uris = {}
-        self.connect()
+        # self.connect()
 
     def get_virtual_machine_error(self, exception: Exception, **kwargs) -> VirtualMachineError:
         txn = kwargs.get("txn")

--- a/ape_infura/provider.py
+++ b/ape_infura/provider.py
@@ -52,7 +52,8 @@ class Infura(Web3Provider, UpstreamProvider):
 
     def __get_random_api_key(self) -> str:
         """
-        Get a random api key a private method. As self.api_keys are unhashable so have to typecast into list to make it hashable
+        Get a random api key a private method. As self.api_keys are unhashable so have to typecast into list
+        to make it hashable
         """
         return random.choice(list(self.api_keys))
 

--- a/ape_infura/provider.py
+++ b/ape_infura/provider.py
@@ -116,7 +116,6 @@ class Infura(Web3Provider, UpstreamProvider):
         self.disconnect()
         self.load_api_keys()
         self.network_uris = {}
-        # self.connect()
 
     def get_virtual_machine_error(self, exception: Exception, **kwargs) -> VirtualMachineError:
         txn = kwargs.get("txn")

--- a/ape_infura/provider.py
+++ b/ape_infura/provider.py
@@ -10,12 +10,7 @@ from web3.exceptions import ContractLogicError as Web3ContractLogicError
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.middleware import geth_poa_middleware
 
-_ENVIRONMENT_VARIABLE_NAMES = (
-    "WEB3_INFURA_PROJECT_ID",
-    "WEB3_INFURA_API_KEY",
-    "WEB3_INFURA_PROJECT_IDS",
-    "WEB3_INFURA_API_KEYS",
-)
+_ENVIRONMENT_VARIABLE_NAMES = ("WEB3_INFURA_PROJECT_ID", "WEB3_INFURA_API_KEY")
 # NOTE: https://docs.infura.io/learn/websockets#supported-networks
 _WEBSOCKET_CAPABLE_ECOSYSTEMS = {
     "ethereum",
@@ -51,10 +46,7 @@ class Infura(Web3Provider, UpstreamProvider):
         for env_var_name in _ENVIRONMENT_VARIABLE_NAMES:
             env_var = os.environ.get(env_var_name)
             if env_var:
-                if env_var_name.endswith("S"):  # Handle array-like environment variables
-                    self.api_keys.extend([key.strip() for key in env_var.split(",")])
-                else:
-                    self.api_keys.append(env_var)
+                self.api_keys.extend([key.strip() for key in env_var.split(",")])
 
         if not self.api_keys:
             raise MissingProjectKeyError()

--- a/ape_infura/provider.py
+++ b/ape_infura/provider.py
@@ -52,8 +52,7 @@ class Infura(Web3Provider, UpstreamProvider):
 
     def __get_random_api_key(self) -> str:
         """
-        Get a random api key a private method. As self.api_keys are unhashable so have to typecast into list
-        to make it hashable
+        Get a random api key a private method.
         """
         return random.choice(list(self.api_keys))
 
@@ -104,16 +103,12 @@ class Infura(Web3Provider, UpstreamProvider):
         self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
 
     def disconnect(self):
-        self._web3 = None
-
-    def reconnect(self):
         """
         Disconnect the connected API.
         Refresh the API keys from environment variable.
         Make the self.network_uris empty otherwise the old network_uri will be returned.
-        Connect again.
         """
-        self.disconnect()
+        self._web3 = None
         self.load_api_keys()
         self.network_uris = {}
 

--- a/ape_infura/provider.py
+++ b/ape_infura/provider.py
@@ -44,14 +44,13 @@ class Infura(Web3Provider, UpstreamProvider):
     def load_api_keys(self):
         self.api_keys = []
         for env_var_name in _ENVIRONMENT_VARIABLE_NAMES:
-            env_var = os.environ.get(env_var_name)
-            if env_var:
+            if env_var := os.environ.get(env_var_name):
                 self.api_keys.extend([key.strip() for key in env_var.split(",")])
 
         if not self.api_keys:
             raise MissingProjectKeyError()
 
-    def get_random_api_key(self):
+    def get_random_api_key(self) -> str:
         return random.choice(self.api_keys)
 
     @property

--- a/ape_infura/provider.py
+++ b/ape_infura/provider.py
@@ -107,7 +107,7 @@ class Infura(Web3Provider, UpstreamProvider):
 
     def reconnect(self):
         """
-        Disconnect the connectned API.
+        Disconnect the connected API.
         Refresh the API keys from environment variable.
         Make the self.network_uris empty otherwise the old network_uri will be returned.
         Connect again.

--- a/ape_infura/provider.py
+++ b/ape_infura/provider.py
@@ -67,6 +67,19 @@ class Infura(Web3Provider, UpstreamProvider):
         self.network_uris[(ecosystem_name, network_name)] = network_uri
         return network_uri
 
+    def get_new_uri(self) -> str:
+        """
+        To generate a new URI with a new API key. Added to keep backwards compatibity
+        """
+        key = self.get_random_api_key()
+        ecosystem_name = self.network.ecosystem.name
+        network_name = self.network.name
+
+        prefix = f"{ecosystem_name}-" if ecosystem_name != "ethereum" else ""
+        network_uri = f"https://{prefix}{network_name}.infura.io/v3/{key}"
+        self.network_uris[(ecosystem_name, network_name)] = network_uri
+        return network_uri
+
     @property
     def http_uri(self) -> str:
         # NOTE: Overriding `Web3Provider.http_uri` implementation

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ extras_require = {
     "test": [  # `test` GitHub Action jobs uses this
         "pytest>=6.0",  # Core testing package
         "pytest-xdist",  # Multi-process runner
+        "pytest-mock",
         "pytest-cov",  # Coverage analyzer plugin
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
         "ape-arbitrum",  # For integration testing

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ extras_require = {
     "test": [  # `test` GitHub Action jobs uses this
         "pytest>=6.0",  # Core testing package
         "pytest-xdist",  # Multi-process runner
-        "pytest-mock",
+        "pytest-mock",  # Mocking framework
         "pytest-cov",  # Coverage analyzer plugin
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
         "ape-arbitrum",  # For integration testing

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -66,7 +66,7 @@ def test_uri_with_random_api_key(provider, mocker):
     provider.load_api_keys()
     uris = set()
     for _ in range(100):  # Generate multiple URIs
-        provider.reconnect()  # connect to a new URI
+        provider.disconnect()  # connect to a new URI
         uri = provider.uri
         uris.add(uri)
         assert uri.startswith("https")

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -61,21 +61,13 @@ def test_load_single_and_multiple_api_keys(provider, mocker):
     assert "single_key2" in provider.api_keys
 
 
-def test_random_api_key_selection(provider, mocker):
-    mocker.patch.dict(os.environ, {"WEB3_INFURA_PROJECT_ID": "key1,key2,key3,key4,key5"})
-    provider.load_api_keys()
-    selected_keys = set()
-    for _ in range(50):  # Run multiple times to ensure randomness
-        selected_keys.add(provider.get_random_api_key())
-    assert len(selected_keys) > 1  # Ensure we're getting different keys
-
-
 def test_uri_with_random_api_key(provider, mocker):
     # mocker.patch.dict(os.environ, {"WEB3_INFURA_PROJECT_ID": "key1, key2, key3, key4, key5, key6"})
     provider.load_api_keys()
     uris = set()
     for _ in range(100):  # Generate multiple URIs
-        uri = provider.get_new_uri()  # Use get_new_uri method to get a URI
+        provider.reconnect()  # connect to a new URI
+        uri = provider.uri
         uris.add(uri)
         assert uri.startswith("https")
         assert "/v3" in uri

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import requests
 import websocket  # type: ignore
 from ape.utils import ZERO_ADDRESS
 
@@ -62,7 +63,7 @@ def test_load_single_and_multiple_api_keys(provider, mocker):
 
 
 def test_uri_with_random_api_key(provider, mocker):
-    # mocker.patch.dict(os.environ, {"WEB3_INFURA_PROJECT_ID": "key1, key2, key3, key4, key5, key6"})
+    mocker.patch.dict(os.environ, {"WEB3_INFURA_PROJECT_ID": "key1, key2, key3, key4, key5, key6"})
     provider.load_api_keys()
     uris = set()
     for _ in range(100):  # Generate multiple URIs
@@ -72,9 +73,3 @@ def test_uri_with_random_api_key(provider, mocker):
         assert uri.startswith("https")
         assert "/v3" in uri
     assert len(uris) > 1  # Ensure we're getting different URIs with different
-
-
-def test_missing_project_key_error_raised(provider, mocker):
-    mocker.patch.dict(os.environ, {}, clear=True)
-    with pytest.raises(MissingProjectKeyError):
-        provider.load_api_keys()

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-import requests
 import websocket  # type: ignore
 from ape.utils import ZERO_ADDRESS
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -71,8 +71,7 @@ def test_random_api_key_selection(provider):
         assert len(selected_keys) > 1  # Ensure we're getting different keys
 
 
-def test_missing_project_key_error_raised():
-    provider = Infura()
+def test_missing_project_key_error_raised(provider):
     with patch.dict(os.environ, {}, clear=True):
         with pytest.raises(MissingProjectKeyError):
             provider.load_api_keys()

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -4,7 +4,7 @@ import pytest
 import websocket  # type: ignore
 from ape.utils import ZERO_ADDRESS
 
-from ape_infura.provider import _WEBSOCKET_CAPABLE_ECOSYSTEMS, Infura, MissingProjectKeyError
+from ape_infura.provider import _WEBSOCKET_CAPABLE_ECOSYSTEMS, Infura
 
 
 def test_infura_http(provider):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,10 +1,11 @@
+import os
 from unittest.mock import patch
 
 import pytest
 import websocket  # type: ignore
 from ape.utils import ZERO_ADDRESS
 
-from ape_infura.provider import _WEBSOCKET_CAPABLE_ECOSYSTEMS, Infura
+from ape_infura.provider import _WEBSOCKET_CAPABLE_ECOSYSTEMS, Infura, MissingProjectKeyError
 
 
 def test_infura_http(provider):
@@ -38,10 +39,11 @@ def test_infura_ws(provider):
 def test_load_multiple_api_keys(provider):
     with patch.dict(
         os.environ,
-        {"WEB3_INFURA_PROJECT_IDS": "key1,key2,key3", "WEB3_INFURA_API_KEYS": "key4,key5,key6"},
+        {"WEB3_INFURA_PROJECT_ID": "key1,key2,key3", "WEB3_INFURA_API_KEY": "key4,key5,key6"},
     ):
         provider.load_api_keys()
-        assert len(provider.api_keys) == 6
+        # As there will be API keys in the ENV as well
+        assert len(provider.api_keys) >= 6
         assert "key1" in provider.api_keys
         assert "key6" in provider.api_keys
 
@@ -52,17 +54,16 @@ def test_load_single_and_multiple_api_keys(provider):
         {
             "WEB3_INFURA_PROJECT_ID": "single_key1",
             "WEB3_INFURA_API_KEY": "single_key2",
-            "WEB3_INFURA_PROJECT_IDS": "multi_key1,multi_key2",
         },
     ):
         provider.load_api_keys()
-        assert len(provider.api_keys) == 4
+        assert len(provider.api_keys) >= 2
         assert "single_key1" in provider.api_keys
-        assert "multi_key2" in provider.api_keys
+        assert "single_key2" in provider.api_keys
 
 
 def test_random_api_key_selection(provider):
-    with patch.dict(os.environ, {"WEB3_INFURA_PROJECT_IDS": "key1,key2,key3,key4,key5"}):
+    with patch.dict(os.environ, {"WEB3_INFURA_PROJECT_ID": "key1,key2,key3,key4,key5"}):
         provider.load_api_keys()
         selected_keys = set()
         for _ in range(50):  # Run multiple times to ensure randomness
@@ -70,19 +71,8 @@ def test_random_api_key_selection(provider):
         assert len(selected_keys) > 1  # Ensure we're getting different keys
 
 
-def test_uri_with_random_api_key(provider):
-    with patch.dict(os.environ, {"WEB3_INFURA_PROJECT_IDS": "key1,key2,key3"}):
-        provider.load_api_keys()
-        uris = set()
-        for _ in range(10):  # Generate multiple URIs
-            uri = provider.uri
-            uris.add(uri)
-            assert uri.startswith("https")
-            assert "/v3/key" in uri
-        assert len(uris) > 1  # Ensure we're getting different URIs with different keys
-
-
-def test_missing_project_key_error_raised(provider):
-    with patch.dict("os.environ", {}, clear=True):
+def test_missing_project_key_error_raised():
+    provider = Infura()
+    with patch.dict(os.environ, {}, clear=True):
         with pytest.raises(MissingProjectKeyError):
             provider.load_api_keys()

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -70,6 +70,18 @@ def test_random_api_key_selection(provider, mocker):
     assert len(selected_keys) > 1  # Ensure we're getting different keys
 
 
+def test_uri_with_random_api_key(provider, mocker):
+    # mocker.patch.dict(os.environ, {"WEB3_INFURA_PROJECT_ID": "key1, key2, key3, key4, key5, key6"})
+    provider.load_api_keys()
+    uris = set()
+    for _ in range(100):  # Generate multiple URIs
+        uri = provider.get_new_uri()  # Use get_new_uri method to get a URI
+        uris.add(uri)
+        assert uri.startswith("https")
+        assert "/v3" in uri
+    assert len(uris) > 1  # Ensure we're getting different URIs with different
+
+
 def test_missing_project_key_error_raised(provider, mocker):
     mocker.patch.dict(os.environ, {}, clear=True)
     with pytest.raises(MissingProjectKeyError):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,5 +1,4 @@
 import os
-from unittest.mock import patch
 
 import pytest
 import websocket  # type: ignore
@@ -36,42 +35,42 @@ def test_infura_ws(provider):
         pytest.fail(f"Websocket URI not accessible. Reason: {err}")
 
 
-def test_load_multiple_api_keys(provider):
-    with patch.dict(
+def test_load_multiple_api_keys(provider, mocker):
+    mocker.patch.dict(
         os.environ,
         {"WEB3_INFURA_PROJECT_ID": "key1,key2,key3", "WEB3_INFURA_API_KEY": "key4,key5,key6"},
-    ):
-        provider.load_api_keys()
-        # As there will be API keys in the ENV as well
-        assert len(provider.api_keys) >= 6
-        assert "key1" in provider.api_keys
-        assert "key6" in provider.api_keys
+    )
+    provider.load_api_keys()
+    # As there will be API keys in the ENV as well
+    assert len(provider.api_keys) == 6
+    assert "key1" in provider.api_keys
+    assert "key6" in provider.api_keys
 
 
-def test_load_single_and_multiple_api_keys(provider):
-    with patch.dict(
+def test_load_single_and_multiple_api_keys(provider, mocker):
+    mocker.patch.dict(
         os.environ,
         {
             "WEB3_INFURA_PROJECT_ID": "single_key1",
             "WEB3_INFURA_API_KEY": "single_key2",
         },
-    ):
+    )
+    provider.load_api_keys()
+    assert len(provider.api_keys) == 2
+    assert "single_key1" in provider.api_keys
+    assert "single_key2" in provider.api_keys
+
+
+def test_random_api_key_selection(provider, mocker):
+    mocker.patch.dict(os.environ, {"WEB3_INFURA_PROJECT_ID": "key1,key2,key3,key4,key5"})
+    provider.load_api_keys()
+    selected_keys = set()
+    for _ in range(50):  # Run multiple times to ensure randomness
+        selected_keys.add(provider.get_random_api_key())
+    assert len(selected_keys) > 1  # Ensure we're getting different keys
+
+
+def test_missing_project_key_error_raised(provider, mocker):
+    mocker.patch.dict(os.environ, {}, clear=True)
+    with pytest.raises(MissingProjectKeyError):
         provider.load_api_keys()
-        assert len(provider.api_keys) >= 2
-        assert "single_key1" in provider.api_keys
-        assert "single_key2" in provider.api_keys
-
-
-def test_random_api_key_selection(provider):
-    with patch.dict(os.environ, {"WEB3_INFURA_PROJECT_ID": "key1,key2,key3,key4,key5"}):
-        provider.load_api_keys()
-        selected_keys = set()
-        for _ in range(50):  # Run multiple times to ensure randomness
-            selected_keys.add(provider.get_random_api_key())
-        assert len(selected_keys) > 1  # Ensure we're getting different keys
-
-
-def test_missing_project_key_error_raised(provider):
-    with patch.dict(os.environ, {}, clear=True):
-        with pytest.raises(MissingProjectKeyError):
-            provider.load_api_keys()


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #87

### How I did it
- Added option to load API Keys in random order. Have to define API keys as an array of items. 

#### Example

```sh
# bash/zsh/sh
export WEB3_INFURA_PROJECT_ID="cxxxxxxxxxxxxx, f4xxxxxxxxxxxxx, 6xxxxxxxxxxxxx, axxxxxxxxxxxxx"

# fish
set -gx WEB3_INFURA_PROJECT_IDS "cxxxxxxxxxxxxx, f4xxxxxxxxxxxxx, 6xxxxxxxxxxxxx, axxxxxxxxxxxxx"
```

### How to verify it
- Trust me bro ;)

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
